### PR TITLE
Add support for hex colors of 8 chars (with alpha value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ expandToHexColor('0ff'); // returns '#00FFFF'
 expandToHexColor('000000'); // returns '#000000'
 expandToHexColor('ffffff'); // returns '#FFFFFF'
 expandToHexColor('00000000'); // returns '#000000'
+expandToHexColor('ab77'); // returns '#AABB7777' (HEX8)
 
 /* Converts color name to hex */
 expandToHexColor('red'); // returns '#FF0000'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expand-to-hex-color",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "expand-to-hex-color",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "css-color-names": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expand-to-hex-color",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Expands any string to valid full hex color",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/expandToHexColor.test.ts
+++ b/src/__tests__/expandToHexColor.test.ts
@@ -31,7 +31,7 @@ test('Invalid hex strings', () => {
   expect(expandToHexColor('')).toBe(null);
   expect(expandToHexColor(' ')).toBe(null);
   expect(expandToHexColor('xxz')).toBe(null);
-  expect(expandToHexColor('xxz')).toBe(null);
+  expect(expandToHexColor('xxxz')).toBe(null);
 });
 
 test('Converting names to hex', () => {

--- a/src/__tests__/expandToHexColor.test.ts
+++ b/src/__tests__/expandToHexColor.test.ts
@@ -5,23 +5,23 @@ test('Expanding values', () => {
   expect(expandToHexColor('ff')).toBe('#FFFFFF');
   expect(expandToHexColor('fa')).toBe('#FAFAFA');
   expect(expandToHexColor('0f')).toBe('#0F0F0F');
+  expect(expandToHexColor('99')).toBe('#999999');
   expect(expandToHexColor('faf')).toBe('#FFAAFF');
   expect(expandToHexColor('F00')).toBe('#FF0000');
   expect(expandToHexColor('fff')).toBe('#FFFFFF');
-  expect(expandToHexColor('FFFFFF')).toBe('#FFFFFF');
+  expect(expandToHexColor('023')).toBe('#002233');
+  expect(expandToHexColor('c13')).toBe('#CC1133');
+  expect(expandToHexColor('FF7F')).toBe('#FFFF77FF');
+  expect(expandToHexColor('ab77')).toBe('#AABB7777');
   expect(expandToHexColor('FFFF7')).toBe('#FFFFFF');
-  expect(expandToHexColor('FF7F')).toBe('#FFFF77');
+  expect(expandToHexColor('FFFFFF')).toBe('#FFFFFF');
   expect(expandToHexColor('#f')).toBe('#FFFFFF');
   expect(expandToHexColor('#FF')).toBe('#FFFFFF');
   expect(expandToHexColor('#f00')).toBe('#FF0000');
   expect(expandToHexColor('#fff')).toBe('#FFFFFF');
   expect(expandToHexColor('#ffffff')).toBe('#FFFFFF');
-  expect(expandToHexColor('023')).toBe('#002233');
-  expect(expandToHexColor('c13')).toBe('#CC1133');
-  expect(expandToHexColor('ab77')).toBe('#AABB77');
-  expect(expandToHexColor('99')).toBe('#999999');
+  expect(expandToHexColor('#ffffff05')).toBe('#FFFFFF05');
 });
-
 
 test('Invalid hex strings', () => {
   expect(expandToHexColor('xzz77')).toBe('#777777');
@@ -30,6 +30,7 @@ test('Invalid hex strings', () => {
   expect(expandToHexColor('invalid string')).toBe('#ADADAD');
   expect(expandToHexColor('')).toBe(null);
   expect(expandToHexColor(' ')).toBe(null);
+  expect(expandToHexColor('xxz')).toBe(null);
   expect(expandToHexColor('xxz')).toBe(null);
 });
 
@@ -45,19 +46,18 @@ test('Converting names to hex', () => {
   expect(expandToHexColor('LINeN')).toBe('#FAF0E6');
 });
 
-
 test('Return as lowercase', () => {
   expect(expandToHexColor('C13', 'lowercase')).toBe('#cc1133');
-  expect(expandToHexColor('ab77', 'lowercase')).toBe('#aabb77');
-  expect(expandToHexColor('xzz7a', 'lowercase')).toBe("#7a7a7a");
-  expect(expandToHexColor('xzzc7', 'lowercase')).toBe("#c7c7c7");
+  expect(expandToHexColor('ab77', 'lowercase')).toBe('#aabb7777');
+  expect(expandToHexColor('xzz7a', 'lowercase')).toBe('#7a7a7a');
+  expect(expandToHexColor('xzzc7', 'lowercase')).toBe('#c7c7c7');
   expect(expandToHexColor('batman', 'lowercase')).toBe('#bbaaaa');
 });
 
 test('No hex symbol + lowercase', () => {
   expect(expandToHexColor('c13', 'lowercase', false)).toBe('cc1133');
-  expect(expandToHexColor('ab77', 'lowercase', false)).toBe('aabb77');
-  expect(expandToHexColor('xzz7a', 'lowercase', false)).toBe("7a7a7a");
-  expect(expandToHexColor('xzzc7', 'lowercase', false)).toBe("c7c7c7");
+  expect(expandToHexColor('ab77', 'lowercase', false)).toBe('aabb7777');
+  expect(expandToHexColor('xzz7a', 'lowercase', false)).toBe('7a7a7a');
+  expect(expandToHexColor('xzzc7', 'lowercase', false)).toBe('c7c7c7');
   expect(expandToHexColor('batman', 'lowercase', false)).toBe('bbaaaa');
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export function expandToHexColor(
     }
 
     // A final check to make sure the hex value is valid
-    if (hex.length === 6) {
+    if (hex.length === 6 || hex.length === 8) {
         if (includeHexSymbol) {
             hex = `#${hex}`;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,19 @@ export function expandToHexColor(
         }
 
         // If the hex value has 3 characters, expand it to 6 characters
-        if (hex.length >= 3 && hex.length <= 5) {
-            hex = hex.substring(0, 3)
-              .split("")
-              .map((char) => char + char)
-              .join("");
+        if (hex.length === 3 || hex.length === 5) {
+          hex = hex
+            .substring(0, 3)
+            .split("")
+            .map((char) => char + char)
+            .join("");
+        }
+
+        if (hex.length === 4) {
+          hex = hex
+            .split("")
+            .map((char) => char + char)
+            .join("");
         }
     }
 


### PR DESCRIPTION
- hex colors can also include alpha value (opacity), so extended the support for those as well